### PR TITLE
fix: insert MCP tools and tokens at cursor in CommandsTab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,13 +28,14 @@ tauri-app/mcp-1c-search/**/target/
 *.suo
 *.sln
 *.sw?
-
+.cursor/
 # Project specifics
 _archive/
 specs/
 temp/
 *.tmp
 temp_*.bsl
+memory-bank/
 
 # Sensitive info
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1209,7 +1209,6 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -1460,7 +1459,6 @@
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
             "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -2324,7 +2322,6 @@
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
@@ -2465,7 +2462,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
             "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -2480,7 +2476,7 @@
             }
         },
         "tauri-app": {
-            "version": "1.1.13",
+            "version": "1.1.21",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.26.0",
                 "@monaco-editor/react": "^4.7.0",
@@ -2561,7 +2557,6 @@
             "version": "7.29.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -3647,7 +3642,6 @@
         "tauri-app/node_modules/@types/react": {
             "version": "19.2.11",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -3656,7 +3650,6 @@
             "version": "19.2.3",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -3672,7 +3665,8 @@
         "tauri-app/node_modules/@types/trusted-types": {
             "version": "2.0.7",
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "tauri-app/node_modules/@types/unist": {
             "version": "3.0.3",
@@ -3780,7 +3774,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -3924,6 +3917,7 @@
         "tauri-app/node_modules/dompurify": {
             "version": "3.2.7",
             "license": "(MPL-2.0 OR Apache-2.0)",
+            "peer": true,
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -4373,6 +4367,7 @@
         "tauri-app/node_modules/marked": {
             "version": "14.0.0",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -5188,7 +5183,6 @@
             "version": "4.0.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5214,7 +5208,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -5247,7 +5240,6 @@
         "tauri-app/node_modules/react": {
             "version": "19.2.4",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5255,7 +5247,6 @@
         "tauri-app/node_modules/react-dom": {
             "version": "19.2.4",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -5573,8 +5564,7 @@
         },
         "tauri-app/node_modules/tailwindcss": {
             "version": "4.1.18",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "tauri-app/node_modules/tailwindcss-animate": {
             "version": "1.0.7",
@@ -5825,7 +5815,6 @@
             "version": "7.3.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",

--- a/tauri-app/src-tauri/src/commands/mcp.rs
+++ b/tauri-app/src-tauri/src/commands/mcp.rs
@@ -1,5 +1,25 @@
 use crate::mcp_client::{McpClient, McpTool, McpServerStatus};
 use crate::settings::{load_settings, McpServerConfig};
+use serde::{Serialize, Deserialize};
+use serde_json::Value;
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+use std::time::Instant;
+
+/// Struct returned to frontend with aggregated tool metadata
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct McpToolInfo {
+    pub server_name: String,
+    pub tool_name: String,
+    pub description: Option<String>,
+    pub input_schema: Option<Value>,
+    pub is_enabled: bool,
+}
+
+lazy_static! {
+    static ref MCP_TOOLS_CACHE: Mutex<Option<(Vec<McpToolInfo>, Instant)>> = Mutex::new(None);
+}
+const MCP_TOOLS_CACHE_TTL_SECS: u64 = 300;
 
 /// Get available MCP tools from a specific server
 #[tauri::command]
@@ -25,6 +45,91 @@ pub async fn get_mcp_tools(server_id: String) -> Result<Vec<McpTool>, String> {
 
     let client = McpClient::new(config).await?;
     client.list_tools().await
+}
+
+/// List tools across all enabled MCP servers (cached)
+#[tauri::command]
+pub async fn list_mcp_tools(force_refresh: Option<bool>) -> Result<Vec<McpToolInfo>, String> {
+    let force = force_refresh.unwrap_or(false);
+
+    // Check cache
+    if !force {
+        if let Ok(cache_lock) = MCP_TOOLS_CACHE.lock() {
+            if let Some((cached, ts)) = &*cache_lock {
+                if ts.elapsed().as_secs() < MCP_TOOLS_CACHE_TTL_SECS {
+                    return Ok(cached.clone());
+                }
+            }
+        }
+    }
+
+    let settings = load_settings();
+    let mut result: Vec<McpToolInfo> = Vec::new();
+
+    // Helper to process a single server config
+    let process_server = |config: McpServerConfig| async move {
+        let mut server_tools: Vec<McpToolInfo> = Vec::new();
+        match McpClient::new(config.clone()).await {
+            Ok(client) => match client.list_tools().await {
+                Ok(tools) => {
+                    for t in tools {
+                        server_tools.push(McpToolInfo {
+                            server_name: config.name.clone(),
+                            tool_name: t.name,
+                            description: Some(t.description),
+                            input_schema: Some(t.input_schema),
+                            is_enabled: true,
+                        });
+                    }
+                }
+                Err(e) => {
+                    server_tools.push(McpToolInfo {
+                        server_name: config.name.clone(),
+                        tool_name: "__server_unavailable__".to_string(),
+                        description: Some(format!("Failed to list tools: {}", e)),
+                        input_schema: None,
+                        is_enabled: false,
+                    });
+                }
+            },
+            Err(e) => {
+                server_tools.push(McpToolInfo {
+                    server_name: config.name.clone(),
+                    tool_name: "__server_unavailable__".to_string(),
+                    description: Some(format!("Failed to create client: {}", e)),
+                    input_schema: None,
+                    is_enabled: false,
+                });
+            }
+        }
+        server_tools
+    };
+
+    // Iterate configured MCP servers
+    for cfg in settings.mcp_servers.iter().filter(|s| s.enabled).cloned() {
+        let mut tools = process_server(cfg).await;
+        result.append(&mut tools);
+    }
+
+    // Include BSL LS as internal server if enabled
+    if settings.bsl_server.enabled {
+        let cfg = crate::settings::McpServerConfig {
+            id: "bsl-ls".to_string(),
+            name: "BSL Language Server".to_string(),
+            enabled: settings.bsl_server.enabled,
+            transport: crate::settings::McpTransport::Internal,
+            ..Default::default()
+        };
+        let mut tools = process_server(cfg).await;
+        result.append(&mut tools);
+    }
+
+    // Update cache
+    if let Ok(mut cache_lock) = MCP_TOOLS_CACHE.lock() {
+        *cache_lock = Some((result.clone(), Instant::now()));
+    }
+
+    Ok(result)
 }
 
 /// Get status of all MCP servers

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -74,6 +74,7 @@ pub fn run() {
             restart_app_cmd,
             // MCP
             get_mcp_tools,
+            list_mcp_tools,
             call_mcp_tool,
             test_mcp_connection,
             get_mcp_server_statuses,

--- a/tauri-app/src/components/CodeSidePanel/Header.tsx
+++ b/tauri-app/src/components/CodeSidePanel/Header.tsx
@@ -1,9 +1,9 @@
-import { X, AlertTriangle, AlertCircle, FileCode, ArrowLeftRight, ChevronUp, ChevronDown, Trash2, Maximize2, Minimize2 } from 'lucide-react';
+import { X, AlertTriangle, AlertCircle, FileCode, ArrowLeftRight, ChevronUp, ChevronDown, Trash2, Maximize2, Minimize2, Wrench } from 'lucide-react';
 import { useSettings } from '@/contexts/SettingsContext';
 
 interface HeaderProps {
-    viewMode: 'editor' | 'diff';
-    setViewMode: (mode: 'editor' | 'diff') => void;
+    viewMode: 'editor' | 'diff' | 'tools';
+    setViewMode: (mode: 'editor' | 'diff' | 'tools') => void;
     isValidating: boolean;
     errorCount: number;
     warningCount: number;
@@ -114,6 +114,16 @@ export function Header({
                     >
                         <ArrowLeftRight className="w-3 h-3" />
                         <span>Diff</span>
+                    </button>
+                    <button
+                        onClick={() => setViewMode('tools')}
+                        className={`px-2 py-0.5 rounded text-[10px] font-medium transition-colors flex items-center gap-1.5 ${
+                            viewMode === 'tools' ? activeTabClass : inactiveTabClass
+                        }`}
+                        title="MCP Tools"
+                    >
+                        <Wrench className="w-3 h-3" />
+                        <span>MCP</span>
                     </button>
                 </div>
 

--- a/tauri-app/src/components/CodeSidePanel/McpToolsView.tsx
+++ b/tauri-app/src/components/CodeSidePanel/McpToolsView.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import type { McpToolInfo } from '@/types/mcp';
+import { Wrench, RefreshCw, Info } from 'lucide-react';
+
+interface McpToolsViewProps {
+    serverName?: string | null;
+}
+
+export function McpToolsView({ serverName }: McpToolsViewProps) {
+    const [tools, setTools] = useState<McpToolInfo[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+    const [expandedTool, setExpandedTool] = useState<string | null>(null);
+
+    const fetchTools = async (force = false) => {
+        setLoading(true);
+        setError(null);
+        try {
+            // Tauri invoke: command name and single arg object
+            const res = (await invoke('list_mcp_tools', { force_refresh: force })) as McpToolInfo[];
+            let filtered = serverName ? res.filter(t => t.server_name === serverName) : res;
+            // Deduplicate tools by tool_name (keep first occurrence)
+            const seen = new Set<string>();
+            const deduped: McpToolInfo[] = [];
+            for (const t of filtered) {
+                if (!seen.has(t.tool_name)) {
+                    seen.add(t.tool_name);
+                    deduped.push(t);
+                }
+            }
+            setTools(deduped);
+        } catch (e: any) {
+            setError(e?.toString() || 'Failed to fetch tools');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchTools(false);
+    }, [serverName]);
+
+    const grouped = tools.reduce<Record<string, McpToolInfo[]>>((acc, t) => {
+        acc[t.server_name] = acc[t.server_name] || [];
+        acc[t.server_name].push(t);
+        return acc;
+    }, {});
+
+    if (loading) {
+        return <div className="p-4"><div className="text-sm text-zinc-500">Loading MCP tools...</div></div>;
+    }
+
+    if (error) {
+        return (
+            <div className="p-4">
+                <div className="text-sm text-red-400 mb-2">Error: {error}</div>
+                <button onClick={() => fetchTools(true)} className="px-3 py-1 bg-zinc-800 rounded">Retry</button>
+            </div>
+        );
+    }
+
+    const serverNames = Object.keys(grouped);
+    if (serverNames.length === 0) {
+        return <div className="p-4 text-sm text-zinc-500">No MCP tools available.</div>;
+    }
+
+    return (
+        <div className="p-3 overflow-auto max-h-full">
+            <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                    <Wrench className="w-4 h-4" /> MCP Tools
+                </div>
+                <div>
+                    <button onClick={() => fetchTools(true)} className="px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 text-sm flex items-center gap-2">
+                        <RefreshCw className="w-3.5 h-3.5" /> Refresh
+                    </button>
+                </div>
+            </div>
+            <div className="flex flex-col gap-3">
+                {serverNames.map(server => (
+                    <div key={server} className="border border-zinc-800 rounded-lg p-3">
+                        <div className="flex items-center justify-between mb-2">
+                            <div className="text-sm font-semibold">{server}</div>
+                        </div>
+                        <div className="grid grid-cols-1 gap-2">
+                            {grouped[server].map(tool => {
+                                const isExpanded = expandedTool === tool.tool_name;
+                                return (
+                                    <div
+                                        key={tool.tool_name}
+                                        className={`p-2 border border-zinc-700 rounded transition-colors ${isExpanded ? 'bg-zinc-900' : 'hover:bg-zinc-900'} cursor-pointer`}
+                                        onClick={() => setExpandedTool(isExpanded ? null : tool.tool_name)}
+                                        role="button"
+                                        tabIndex={0}
+                                    >
+                                        <div className="flex items-center justify-between">
+                                            <div className="min-w-0">
+                                                <div className="text-sm font-medium truncate">{tool.tool_name}</div>
+                                                <div
+                                                    className="text-xs text-zinc-500"
+                                                    style={{
+                                                        overflow: 'hidden',
+                                                        maxHeight: isExpanded ? '1000px' : '3.2rem',
+                                                        transition: 'max-height 220ms ease'
+                                                    }}
+                                                >
+                                                    <div className={isExpanded ? '' : 'line-clamp-2'}>
+                                                        {tool.description ?? ''}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div className="ml-3 flex items-center gap-2">
+                                                <div className={`w-2.5 h-2.5 rounded-full ${tool.is_enabled ? 'bg-emerald-400' : 'bg-zinc-600'}`} />
+                                                <button
+                                                    className="text-zinc-400 hover:text-zinc-200 p-1"
+                                                    title="Info"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        setExpandedTool(isExpanded ? null : tool.tool_name);
+                                                    }}
+                                                >
+                                                    <Info className="w-4 h-4" />
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export default McpToolsView;
+

--- a/tauri-app/src/components/CodeSidePanel/index.tsx
+++ b/tauri-app/src/components/CodeSidePanel/index.tsx
@@ -6,6 +6,7 @@ import { useResizing } from './useResizing';
 import { Header } from './Header';
 import { Footer } from './Footer';
 import { DiagnosticsView } from './DiagnosticsView';
+import McpToolsView from './McpToolsView';
 import { applyDiffWithDiagnostics, hasDiffBlocks } from '../../utils/diffViewer';
 import { useSettings } from '@/contexts/SettingsContext';
 
@@ -26,7 +27,7 @@ export function CodeSidePanel({
     onDiffRejected,
     isFullWidth
 }: CodeSidePanelProps) {
-    const [viewMode, setViewMode] = useState<'editor' | 'diff'>('diff');
+    const [viewMode, setViewMode] = useState<'editor' | 'diff' | 'tools'>('diff');
     const [localOriginalCode, setLocalOriginalCode] = useState(originalCode ?? '');
     const { settings } = useSettings();
     const monacoTheme = settings?.theme === 'light' ? 'vs' : 'vs-dark';
@@ -354,7 +355,7 @@ export function CodeSidePanel({
                             readOnly: false,
                         }}
                     />
-                ) : (
+                ) : viewMode === 'diff' ? (
                     <DiffEditor
                         height="100%"
                         language="bsl"
@@ -570,6 +571,8 @@ export function CodeSidePanel({
                             ignoreTrimWhitespace: false,
                         }}
                     />
+                ) : (
+                    <McpToolsView />
                 )}
             </div>
 

--- a/tauri-app/src/components/chat/ChatArea.tsx
+++ b/tauri-app/src/components/chat/ChatArea.tsx
@@ -5,7 +5,7 @@ import { useSettings } from '../../contexts/SettingsContext';
 import { useConfigurator } from '../../contexts/ConfiguratorContext';
 import { parseConfiguratorTitle, ConfiguratorTitleContext } from '../../utils/configurator';
 import { MarkdownRenderer, cleanDiffArtifacts } from '../MarkdownRenderer';
-import { Loader2, Square, ArrowUp, Settings, ChevronDown, ChevronRight, Monitor, RefreshCw, FileText, MousePointerClick, Brain, BrainCircuit, Check, X, Terminal, Pencil, Play, Send, User, HardHat, Mic, MoreHorizontal, Info } from 'lucide-react';
+import { Loader2, Square, ArrowUp, Settings, ChevronDown, ChevronRight, Monitor, RefreshCw, FileText, MousePointerClick, Brain, BrainCircuit, Check, X, Terminal, Pencil, Play, Send, User, HardHat, Mic, MoreHorizontal, Info, Wrench } from 'lucide-react';
 import { useVoiceInput } from '../../voice/useVoiceInput';
 import logo from '../../assets/logo.png';
 import ToolCallBlock from './ToolCallBlock';
@@ -18,6 +18,7 @@ import { DEFAULT_SLASH_COMMANDS, SlashCommand, CliStatus } from '../../types/set
 import { cliProvidersApi } from '../../api/cli_providers';
 import { QwenAuthModal } from '../settings/QwenAuthModal';
 import { QueuedMessages } from './QueuedMessages';
+import McpToolsPopover from './McpToolsPopover';
 
 interface ChatAreaProps {
     originalCode?: string;
@@ -257,6 +258,7 @@ export function ChatArea({
 
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLTextAreaElement>(null);
+    const [showToolsPopover, setShowToolsPopover] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
@@ -1371,6 +1373,45 @@ export function ChatArea({
                                     </button>
                                 </div>
                             )}
+
+                            {/* MCP Tools popover button — always visible */}
+                            <div className="relative">
+                                <button
+                                    onClick={() => {
+                                        setShowToolsPopover(prev => !prev);
+                                        setShowModelDropdown(false);
+                                    }}
+                                    className="w-8 h-8 flex items-center justify-center rounded-lg bg-zinc-800/50 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-all"
+                                    title="MCP Tools"
+                                >
+                                    <Wrench className="w-4 h-4" />
+                                </button>
+                                {showToolsPopover && (
+                                    <McpToolsPopover
+                                        onToolSelect={(toolName: string) => {
+                                            const textarea = inputRef.current;
+                                            if (!textarea) {
+                                                setInput(prev => (prev ? prev + ` @${toolName} ` : `@${toolName} `));
+                                            } else {
+                                                const start = textarea.selectionStart ?? textarea.value.length;
+                                                const end = textarea.selectionEnd ?? textarea.value.length;
+                                                const before = input.slice(0, start);
+                                                const after = input.slice(end);
+                                                const insertion = `@${toolName} `;
+                                                const next = before + insertion + after;
+                                                setInput(next);
+                                                setTimeout(() => {
+                                                    textarea.focus();
+                                                    const pos = start + insertion.length;
+                                                    textarea.setSelectionRange(pos, pos);
+                                                }, 0);
+                                            }
+                                            setShowToolsPopover(false);
+                                        }}
+                                        onClose={() => setShowToolsPopover(false)}
+                                    />
+                                )}
+                            </div>
 
                             <button onClick={isLoading ? stopChat : () => handleSendMessage()} disabled={!isLoading && !input.trim()} className={`w-8 h-8 flex items-center justify-center rounded-lg transition-colors flex-shrink-0 ${isLoading ? 'bg-red-500/10 text-red-400' : input.trim() ? 'bg-blue-600 text-white' : 'bg-[#27272a] text-zinc-600'}`}>
                                 {isLoading ? <Square className="w-4 h-4 fill-current" /> : <ArrowUp className="w-4 h-4" strokeWidth={2.5} />}

--- a/tauri-app/src/components/chat/McpToolsPopover.tsx
+++ b/tauri-app/src/components/chat/McpToolsPopover.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState, useRef } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import type { McpToolInfo } from '@/types/mcp';
+import { Info, RefreshCw } from 'lucide-react';
+
+interface Props {
+    onToolSelect: (toolName: string) => void;
+    onClose: () => void;
+}
+
+export default function McpToolsPopover({ onToolSelect, onClose }: Props) {
+    const [tools, setTools] = useState<McpToolInfo[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const popoverRef = useRef<HTMLDivElement>(null);
+
+    const fetchTools = async (force = false) => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = (await invoke('list_mcp_tools', { force_refresh: force })) as McpToolInfo[];
+            setTools(res);
+        } catch (e: any) {
+            setError(e?.toString() || 'Failed to fetch tools');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchTools(false);
+    }, []);
+
+    useEffect(() => {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+                onClose();
+            }
+        };
+        const handleEsc = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        document.addEventListener('keydown', handleEsc);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+            document.removeEventListener('keydown', handleEsc);
+        };
+    }, [onClose]);
+
+    const grouped = tools.reduce<Record<string, McpToolInfo[]>>((acc, t) => {
+        acc[t.server_name] = acc[t.server_name] || [];
+        acc[t.server_name].push(t);
+        return acc;
+    }, {});
+
+    return (
+        <div
+            ref={popoverRef}
+            className="absolute bottom-full right-0 mb-2 w-80 bg-[#09090b] border border-zinc-800 rounded-xl shadow-2xl overflow-hidden z-50 animate-in slide-in-from-bottom-2 duration-200"
+        >
+            <div className="flex items-center justify-between px-3 py-2 border-b border-zinc-800">
+                <div className="text-sm font-semibold text-zinc-200">MCP Tools</div>
+                <div className="flex items-center gap-2">
+                    <button onClick={() => fetchTools(true)} className="p-1 rounded hover:bg-zinc-800" title="Refresh">
+                        <RefreshCw className="w-3.5 h-3.5 text-zinc-400" />
+                    </button>
+                    <button onClick={onClose} className="p-1 rounded hover:bg-zinc-800 text-zinc-500 hover:text-zinc-300 text-xs font-bold">
+                        ✕
+                    </button>
+                </div>
+            </div>
+            <div className="max-h-72 overflow-y-auto custom-scrollbar">
+                {loading && <div className="p-3 text-sm text-zinc-500">Loading...</div>}
+                {error && <div className="p-3 text-sm text-red-400">Error: {error}</div>}
+                {!loading && !error && Object.keys(grouped).length === 0 && (
+                    <div className="p-3 text-sm text-zinc-500">No tools available</div>
+                )}
+                {!loading && !error && Object.entries(grouped).map(([server, arr]) => (
+                    <div key={server} className="border-b border-zinc-800/50 last:border-b-0">
+                        <div className="px-3 py-1.5 text-[10px] font-bold text-zinc-500 uppercase tracking-wider bg-zinc-900/50">{server}</div>
+                        <div className="flex flex-col">
+                            {arr.map(t => (
+                                <button
+                                    key={t.tool_name}
+                                    onClick={() => onToolSelect(t.tool_name)}
+                                    className="flex items-center justify-between px-3 py-2 hover:bg-zinc-800/50 text-left transition-colors"
+                                >
+                                    <div className="min-w-0 flex-1">
+                                        <div className="text-[12px] font-medium text-zinc-200 truncate">{t.tool_name}</div>
+                                        {t.description && (
+                                            <div className="text-[10px] text-zinc-500 truncate">{t.description}</div>
+                                        )}
+                                    </div>
+                                    <div className="ml-2 flex items-center gap-1.5 flex-shrink-0">
+                                        <div className={`w-2 h-2 rounded-full ${t.is_enabled ? 'bg-emerald-400' : 'bg-zinc-600'}`} />
+                                    </div>
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/tauri-app/src/components/settings/MCPSettings.tsx
+++ b/tauri-app/src/components/settings/MCPSettings.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
-import { Database, Link2, Key, ShieldCheck, Activity, CheckCircle2, AlertCircle, Plus, Trash2, Globe, Settings2, Terminal, Cpu, FileText, X, Sparkles, FolderOpen, ChevronDown, Code } from 'lucide-react';
+import { Database, Link2, Key, ShieldCheck, Activity, CheckCircle2, AlertCircle, Plus, Trash2, Globe, Settings2, Terminal, Cpu, FileText, X, Sparkles, FolderOpen, ChevronDown, Code, Wrench } from 'lucide-react';
+import McpToolsView from '../CodeSidePanel/McpToolsView';
 
 // ── Benchmark Panel ───────────────────────────────────────────────────────────
 
@@ -182,6 +183,7 @@ export function MCPSettings({ servers, onUpdate }: MCPSettingsProps) {
     const [testResults, setTestResults] = useState<Record<string, { success: boolean; message: string }>>({});
     const [statuses, setStatuses] = useState<Record<string, McpServerStatus>>({});
     const [viewingLogsId, setViewingLogsId] = useState<string | null>(null);
+    const [viewingToolsId, setViewingToolsId] = useState<string | null>(null);
     const [logs, setLogs] = useState<string[]>([]);
     const [isLoadingLogs, setIsLoadingLogs] = useState(false);
     const [smartImportId, setSmartImportId] = useState<string | null>(null);
@@ -1199,6 +1201,14 @@ export function MCPSettings({ servers, onUpdate }: MCPSettingsProps) {
                                                 {testingId === server.id ? 'Checking...' : 'Проверить'}
                                             </button>
                                             <button
+                                                onClick={() => setViewingToolsId(server.id)}
+                                                disabled={!server.enabled}
+                                                className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-semibold bg-zinc-700 hover:bg-zinc-600 text-zinc-300 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                                            >
+                                                <Wrench className="w-3.5 h-3.5" />
+                                                Tools
+                                            </button>
+                                            <button
                                                 onClick={() => setViewingLogsId(server.id)}
                                                 disabled={!server.enabled}
                                                 className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-semibold bg-zinc-700 hover:bg-zinc-600 text-zinc-300 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
@@ -1219,6 +1229,28 @@ export function MCPSettings({ servers, onUpdate }: MCPSettingsProps) {
                             </div>
                         );
                     })}
+                </div>
+            )}
+            {/* Tools Modal */}
+            {viewingToolsId && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
+                    <div className="bg-zinc-800 border border-zinc-700 rounded-xl w-full max-w-3xl h-[600px] flex flex-col shadow-2xl">
+                        <div className="px-4 py-3 border-b border-zinc-700 flex items-center justify-between">
+                            <h3 className="font-medium text-zinc-100 flex items-center gap-2">
+                                <Wrench className="w-4 h-4 text-zinc-400" />
+                                MCP Tools: {servers.find(s => s.id === viewingToolsId)?.name}
+                            </h3>
+                            <button
+                                onClick={() => setViewingToolsId(null)}
+                                className="p-1 hover:bg-zinc-700 rounded text-zinc-400 hover:text-zinc-200 transition"
+                            >
+                                <X className="w-5 h-5" />
+                            </button>
+                        </div>
+                        <div className="flex-1 overflow-auto">
+                            <McpToolsView serverName={servers.find(s => s.id === viewingToolsId)?.name ?? null} />
+                        </div>
+                    </div>
                 </div>
             )}
 

--- a/tauri-app/src/components/settings/SlashCommandsTab.tsx
+++ b/tauri-app/src/components/settings/SlashCommandsTab.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { Save, Plus, Trash2, Command, Shield, Edit2, RotateCcw, ChevronDown, ChevronUp, Terminal, TextCursorInput } from 'lucide-react';
+import { Save, Plus, Trash2, Command, Shield, Edit2, RotateCcw, ChevronDown, ChevronUp, Terminal, TextCursorInput, Wrench } from 'lucide-react';
 import {
     AppSettings,
     SlashCommand,
     DEFAULT_SLASH_COMMANDS
 } from '../../types/settings';
+import McpToolsPopover from '../chat/McpToolsPopover';
 
 function TokenCode({ code, colorClass = 'text-blue-400/80 bg-blue-400/5', onSelect }: { code: string, colorClass?: string, onSelect?: (code: string) => void }) {
     const [copied, setCopied] = useState(false);
@@ -39,6 +40,8 @@ interface SlashCommandsTabProps {
 
 export function SlashCommandsTab({ settings, onSettingsChange, onSave, saving }: SlashCommandsTabProps) {
     const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+    const [mcpPopoverIndex, setMcpPopoverIndex] = useState<number | null>(null);
+    const textareaRefs = React.useRef<Record<string, HTMLTextAreaElement | null>>({});
 
     const slashCommands = settings.slash_commands || DEFAULT_SLASH_COMMANDS;
 
@@ -216,6 +219,7 @@ export function SlashCommandsTab({ settings, onSettingsChange, onSave, saving }:
                                         <label className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider">Шаблон промпта</label>
                                     </div>
                                     <textarea
+                                        ref={el => (textareaRefs.current[cmd.id] = el)}
                                         value={cmd.template}
                                         onChange={e => updateCommand(index, { template: e.target.value })}
                                         className="w-full h-32 bg-[#1e1e21] border border-white/[0.05] rounded-lg px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-blue-500/50 transition-colors resize-none font-mono leading-relaxed shadow-inner"
@@ -226,7 +230,25 @@ export function SlashCommandsTab({ settings, onSettingsChange, onSave, saving }:
                                             <span className="text-[10px] text-zinc-600">Код:</span>
                                             <TokenCode
                                                 code="{code}"
-                                                onSelect={(c) => updateCommand(index, { template: cmd.template + c })}
+                                                onSelect={(c) => {
+                                                    const ta = textareaRefs.current[cmd.id];
+                                                    if (!ta) {
+                                                        updateCommand(index, { template: cmd.template + c });
+                                                        return;
+                                                    }
+                                                    const start = ta.selectionStart ?? cmd.template.length;
+                                                    const end = ta.selectionEnd ?? start;
+                                                    const before = cmd.template.slice(0, start);
+                                                    const after = cmd.template.slice(end);
+                                                    const next = before + c + after;
+                                                    updateCommand(index, { template: next });
+                                                    // restore focus & caret after inserted text
+                                                    setTimeout(() => {
+                                                        ta.focus();
+                                                        const pos = start + c.length;
+                                                        ta.setSelectionRange(pos, pos);
+                                                    }, 0);
+                                                }}
                                             />
                                         </div>
                                         <div className="flex items-center gap-2">
@@ -234,7 +256,24 @@ export function SlashCommandsTab({ settings, onSettingsChange, onSave, saving }:
                                             <TokenCode
                                                 code="{diagnostics}"
                                                 colorClass="text-red-400/80 bg-red-400/5"
-                                                onSelect={(c) => updateCommand(index, { template: cmd.template + c })}
+                                                onSelect={(c) => {
+                                                    const ta = textareaRefs.current[cmd.id];
+                                                    if (!ta) {
+                                                        updateCommand(index, { template: cmd.template + c });
+                                                        return;
+                                                    }
+                                                    const start = ta.selectionStart ?? cmd.template.length;
+                                                    const end = ta.selectionEnd ?? start;
+                                                    const before = cmd.template.slice(0, start);
+                                                    const after = cmd.template.slice(end);
+                                                    const next = before + c + after;
+                                                    updateCommand(index, { template: next });
+                                                    setTimeout(() => {
+                                                        ta.focus();
+                                                        const pos = start + c.length;
+                                                        ta.setSelectionRange(pos, pos);
+                                                    }, 0);
+                                                }}
                                             />
                                         </div>
                                         <div className="flex items-center gap-2">
@@ -242,8 +281,62 @@ export function SlashCommandsTab({ settings, onSettingsChange, onSave, saving }:
                                             <TokenCode
                                                 code="{query}"
                                                 colorClass="text-green-400/80 bg-green-400/5"
-                                                onSelect={(c) => updateCommand(index, { template: cmd.template + c })}
+                                                onSelect={(c) => {
+                                                    const ta = textareaRefs.current[cmd.id];
+                                                    if (!ta) {
+                                                        updateCommand(index, { template: cmd.template + c });
+                                                        return;
+                                                    }
+                                                    const start = ta.selectionStart ?? cmd.template.length;
+                                                    const end = ta.selectionEnd ?? start;
+                                                    const before = cmd.template.slice(0, start);
+                                                    const after = cmd.template.slice(end);
+                                                    const next = before + c + after;
+                                                    updateCommand(index, { template: next });
+                                                    setTimeout(() => {
+                                                        ta.focus();
+                                                        const pos = start + c.length;
+                                                        ta.setSelectionRange(pos, pos);
+                                                    }, 0);
+                                                }}
                                             />
+                                        </div>
+                                        <div className="relative flex items-center gap-2">
+                                            <button
+                                                onClick={() => setMcpPopoverIndex(prev => (prev === index ? null : index))}
+                                                className="flex items-center gap-1.5 text-[10px] text-purple-400/80 bg-purple-400/5 px-2 py-0.5 rounded cursor-pointer hover:bg-white/5 transition-all active:scale-95 select-none border border-transparent hover:border-white/10"
+                                                title="Добавить MCP инструмент в шаблон"
+                                            >
+                                                <Wrench size={10} />
+                                                MCP
+                                            </button>
+                                            {mcpPopoverIndex === index && (
+                                                <div className="absolute bottom-full left-0 mb-1 z-50">
+                                                    <McpToolsPopover
+                                                        onToolSelect={(toolName: string) => {
+                                                            const insertion = `@${toolName} `;
+                                                            const ta = textareaRefs.current[cmd.id];
+                                                            if (!ta) {
+                                                                updateCommand(index, { template: cmd.template + insertion });
+                                                            } else {
+                                                                const start = ta.selectionStart ?? cmd.template.length;
+                                                                const end = ta.selectionEnd ?? start;
+                                                                const before = cmd.template.slice(0, start);
+                                                                const after = cmd.template.slice(end);
+                                                                const next = before + insertion + after;
+                                                                updateCommand(index, { template: next });
+                                                                setTimeout(() => {
+                                                                    ta.focus();
+                                                                    const pos = start + insertion.length;
+                                                                    ta.setSelectionRange(pos, pos);
+                                                                }, 0);
+                                                            }
+                                                            setMcpPopoverIndex(null);
+                                                        }}
+                                                        onClose={() => setMcpPopoverIndex(null)}
+                                                    />
+                                                </div>
+                                            )}
                                         </div>
                                     </div>
                                     <div className="px-1 pt-1 space-y-1">

--- a/tauri-app/src/types/mcp.ts
+++ b/tauri-app/src/types/mcp.ts
@@ -1,0 +1,13 @@
+export interface McpToolInfo {
+  server_name: string;
+  tool_name: string;
+  description: string | null;
+  input_schema: Record<string, unknown> | null;
+  is_enabled: boolean;
+}
+
+export interface McpToolSummary {
+  name: string;
+  description?: string;
+}
+


### PR DESCRIPTION
# Pull Request: Функционал работы с тулзами MСP в чате

## Описание изменений

Добавлен новый функционал для удобной работы с инструментами MСP непосредственно в интерфейсе чата:

### Основные изменения:

1. **Быстрый доступ к MCP тулзам из чата**
   - Добавлена иконка инструментов в нижней панели чата
   - При нажатии открывается выпадающий список всех доступных MCP тулзов от подключенных серверов (BSL Language Server, 1С:Справка и др.)
   - Возможность быстрого выбора и применения инструмента без перехода в настройки

2. **Просмотр и управление тулзами в настройках**
   - Для каждого MCP сервера добавлена кнопка **"Tools"** в настройках
   - Отображение полного списка инструментов конкретного сервера с их статусом и описанием
   - Централизованное управление доступными инструментами

3. **Интеграция тулзов в команды чата**
   - Добавлена кнопка **"MCP"** в шаблоне промпта при создании/редактировании команд
   - Возможность использования MCP тулзов непосредственно в пользовательских командах (например, `/стандарты`, `/исправить`)
   - Вставка переменных для автоматического применения инструментов к коду

4. **Детальное описание инструментов**
   - Для каждого MCP тулза доступно подробное описание функционала
   - Отображение названия функции, описания на русском языке и статуса доступности
   - Возможность ознакомиться с возможностями инструмента перед его использованием

## Скриншоты / Демонстрация

| Функция | Скриншот |
|---------|----------|
| **Список MCP тулзов в чате**<br>Быстрый доступ к инструментам MSP через иконку в нижней панели чата. Отображает доступные тулзы от всех подключенных серверов (BSL Language Server, 1С:Справка и др.) | ![Screenshot 1](https://github.com/user-attachments/assets/43883a44-c2ea-475d-821f-a7d6c2286c0f ) |
| **Просмотр тулзов в настройках MCP**<br>Кнопка "Tools" в настройках каждого MCP сервера позволяет просмотреть все доступные инструменты конкретного сервера с их статусом и описанием | ![Screenshot 2](https://github.com/user-attachments/assets/46792a92-1f1e-4607-ac4a-40974e76d0ce ) |
| **Использование тулзов в командах**<br>Кнопка "MCP" в шаблоне промпта команд позволяет вставить переменную для использования MSP тулзов непосредственно в командах чата (например, `/стандарты`) | ![Screenshot 3](https://github.com/user-attachments/assets/7be2169b-6b5d-4acf-9f1f-7fa145fed8f8 ) |
| **Детальное описание тулза**<br>Модальное окно с полным описанием инструмента MСP: название функции, подробное описание на русском языке, статус доступности (зеленая галочка) | ![Screenshot 4](https://github.com/user-attachments/assets/296b451c-a785-445f-a625-004009015b1a ) |

Спасибо за рассмотрение!


