### PR TITLE
fix(settings): filter OneCNaparnik from standard LLM cards (#90)

### DIFF
--- a/tauri-app/src/components/settings/LLMSettings.tsx
+++ b/tauri-app/src/components/settings/LLMSettings.tsx
@@ -236,7 +236,7 @@ export function LLMSettings({ profiles, onUpdate }: LLMSettingsProps) {
                             <div className="h-[1px] flex-1 bg-zinc-800"></div>
                         </div>
                         <div className="space-y-1.5">
-                            {profiles.profiles.filter(p => p.provider !== 'QwenCli').map(p => (
+                            {profiles.profiles.filter(p => p.provider !== 'QwenCli' && p.provider !== 'OneCNaparnik').map(p => (
                                 <div
                                     key={p.id}
                                     onClick={() => setEditingId(p.id)}


### PR DESCRIPTION
### Summary
This PR fixes the issue where "1С:Напарник" cards were appearing in both the "Standard LLM" list and the "Naparnik" list.

### Changes
- Updated `LLMSettings.tsx` to strictly filter out `OneCNaparnik` provider from the standard LLM assistants group.

### Fixes
Fixes #90