### PR TITLE
feat: добавить веб-поиск через You.com для документации и ошибок 1С

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# You.com web search API key (https://ydc-index.io)
+YOUCOM_API_KEY=

--- a/tauri-app/src-tauri/src/ai/mod.rs
+++ b/tauri-app/src-tauri/src/ai/mod.rs
@@ -4,6 +4,7 @@ pub mod models;
 pub mod naparnik_client;
 pub mod prompts;
 pub mod tools;
+pub mod youcom_search;
 
 pub use client::*;
 pub use models::*;

--- a/tauri-app/src-tauri/src/ai/prompts.rs
+++ b/tauri-app/src-tauri/src/ai/prompts.rs
@@ -558,6 +558,24 @@ pub fn get_system_prompt(available_tools: &[ToolInfo], messages: &[ApiMessage]) 
         }
     }
 
+    // Add You.com search tool hint if available
+    if available_tools
+        .iter()
+        .any(|t| t.server_id == "builtin-youcom")
+    {
+        prompt.push_str(r#"
+
+=== ВЕБ-ПОИСК (youcom_search) ===
+Используй `youcom_search` для вопросов, требующих актуальной информации из интернета:
+- Поиск документации 1С в интернете
+- Ошибки 1С и их решения (сообщения из интернета)
+- Актуальные версии платформы, конфигураций
+- Любые вопросы выходящие за рамки локальной конфигурации
+
+Вызов: youcom_search(query="ваш вопрос", max_results=10)
+"#);
+    }
+
     prompt
 }
 

--- a/tauri-app/src-tauri/src/ai/tools.rs
+++ b/tauri-app/src-tauri/src/ai/tools.rs
@@ -178,6 +178,38 @@ pub async fn get_available_tools() -> Vec<ToolInfo> {
         *cache = Some((std::time::Instant::now(), all_tools.clone()));
     }
 
+    // Append You.com search tool if API key is configured
+    if let Ok(api_key) = std::env::var("YOUCOM_API_KEY") {
+        if !api_key.trim().is_empty() {
+            crate::app_log!("[MCP][TOOLS]   + Registered (internal): youcom_search");
+            all_tools.push(ToolInfo {
+                server_id: "builtin-youcom".to_string(),
+                tool: Tool {
+                    r#type: "function".to_string(),
+                    function: ToolFunction {
+                        name: "youcom_search".to_string(),
+                        description: "Search the web using You.com. Use this when you need current information, documentation lookups, error explanations, or any question that requires live internet data. Input: query (search string, max ~50 words).".to_string(),
+                        parameters: serde_json::json!({
+                            "type": "object",
+                            "properties": {
+                                "query": {
+                                    "type": "string",
+                                    "description": "Search query (what to search for)"
+                                },
+                                "max_results": {
+                                    "type": "integer",
+                                    "description": "Maximum number of results (1-20, default 10)",
+                                    "default": 10
+                                }
+                            },
+                            "required": ["query"]
+                        }),
+                    },
+                },
+            });
+        }
+    }
+
     all_tools
 }
 

--- a/tauri-app/src-tauri/src/ai/youcom_search.rs
+++ b/tauri-app/src-tauri/src/ai/youcom_search.rs
@@ -1,0 +1,113 @@
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
+use serde::{Deserialize, Serialize};
+
+const YOUCOM_SEARCH_URL: &str = "https://ydc-index.io/v1/search";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct YoucomSearchResult {
+    pub title: String,
+    pub url: String,
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct YoucomResponse {
+    results: Option<Vec<YoucomRawResult>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YoucomRawResult {
+    title: Option<String>,
+    url: Option<String>,
+    #[serde(default)]
+    snippets: Vec<String>,
+    description: Option<String>,
+}
+
+/// Perform a You.com web search.
+pub async fn youcom_search(query: &str, max_results: usize) -> Result<Vec<YoucomSearchResult>, String> {
+    let api_key = std::env::var("YOUCOM_API_KEY")
+        .map_err(|_| "YOUCOM_API_KEY not set")?;
+
+    if api_key.trim().is_empty() {
+        return Err("YOUCOM_API_KEY is empty".to_string());
+    }
+
+    let count = max_results.clamp(1, 20);
+    let client = reqwest::Client::new();
+
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(
+        "X-API-Key",
+        HeaderValue::from_str(&api_key).map_err(|e| format!("Invalid API key header: {}", e))?,
+    );
+
+    let response = client
+        .post(YOUCOM_SEARCH_URL)
+        .headers(headers)
+        .json(&serde_json::json!({
+            "query": query,
+            "count": count
+        }))
+        .timeout(std::time::Duration::from_secs(15))
+        .send()
+        .await
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    let status = response.status();
+    if status.as_u16() == 429 {
+        return Err("You.com rate limit exceeded (429)".to_string());
+    }
+    if status.as_u16() == 401 {
+        return Err("You.com API key invalid or expired (401)".to_string());
+    }
+    if !status.is_success() {
+        return Err(format!("You.com search failed with status {}", status));
+    }
+
+    let body: YoucomResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    let results = body
+        .results
+        .unwrap_or_default()
+        .into_iter()
+        .take(count)
+        .map(|item| YoucomSearchResult {
+            title: item.title.unwrap_or_default(),
+            url: item.url.unwrap_or_default(),
+            content: if item.snippets.is_empty() {
+                item.description.unwrap_or_default()
+            } else {
+                item.snippets[0].clone()
+            },
+        })
+        .collect();
+
+    Ok(results)
+}
+
+/// Format search results as a readable string for the AI.
+pub fn format_search_results(results: Vec<YoucomSearchResult>) -> String {
+    if results.is_empty() {
+        return "No results found.".to_string();
+    }
+
+    results
+        .into_iter()
+        .enumerate()
+        .map(|(i, r)| {
+            format!(
+                "[{}] {}\nURL: {}\n{}\n---",
+                i + 1,
+                r.title,
+                r.url,
+                r.content
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/tauri-app/src-tauri/src/commands/ai.rs
+++ b/tauri-app/src-tauri/src/commands/ai.rs
@@ -712,6 +712,51 @@ pub async fn stream_chat(
                     );
 
                     let mut tool_result = "Error: Tool not found".to_string();
+
+                    // Handle youcom_search directly (internal tool, not via MCP)
+                    if tool_name == "youcom_search" {
+                        let query = arguments
+                            .get("query")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default();
+                        let max_results = arguments
+                            .get("max_results")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(10) as usize;
+
+                        if query.is_empty() {
+                            tool_result = "Error: query parameter is required".to_string();
+                        } else {
+                            crate::app_log!("[AI][TOOL][Youcom] Searching for: {}", query);
+                            match crate::ai::youcom_search::youcom_search(query, max_results).await {
+                                Ok(results) => {
+                                    tool_result = crate::ai::youcom_search::format_search_results(results);
+                                }
+                                Err(e) => {
+                                    crate::app_log!("[AI][TOOL][Youcom] Search error: {}", e);
+                                    tool_result = format!("You.com search error: {}", e);
+                                }
+                            }
+                        }
+
+                        let _ = task_app_handle.emit(
+                            "tool-call-completed",
+                            serde_json::json!({
+                                "id": tool_call.id,
+                                "status": if tool_result.starts_with("Error") || tool_result.starts_with("You.com") { "error" } else { "done" },
+                                "result": tool_result
+                            }),
+                        );
+                        api_messages.push(ApiMessage {
+                            role: "tool".to_string(),
+                            content: Some(tool_result),
+                            tool_call_id: Some(tool_call.id.clone()),
+                            tool_calls: None,
+                            name: Some(tool_name.clone()),
+                        });
+                        continue;
+                    }
+
                     let mut all_configs = settings.mcp_servers.clone();
 
                     if !all_configs.iter().any(|c| c.id == "bsl-ls") {


### PR DESCRIPTION
## Что сделано

Добавлен инструмент `youcom_search` для веб-поиска актуальной информации, выходящей за рамки локальной конфигурации 1С.

## Изменения

- `ai/youcom_search.rs` — клиент You.com Search API (`ydc-index.io`)
- `ai/tools.rs` — регистрация `youcom_search` как внутреннего инструмента при наличии `YOUCOM_API_KEY`
- `commands/ai.rs` — обработка вызовов `youcom_search` напрямую (без MCP)
- `ai/prompts.rs` — подсказка в системном промпте для использования `youcom_search`
- `.env.example` — добавлена переменная `YOUCOM_API_KEY`

## Использование

Установить `YOUCOM_API_KEY` в `.env` (https://ydc-index.io) — инструмент автоматически появится в списке доступных инструментов.

## Тестирование

- [ ] Проверить поиск документации 1С в интернете
- [ ] Проверить поиск ошибок и их решений
- [ ] Убедиться, что при отсутствии `YOUCOM_API_KEY` инструмент не появляется