### PR TITLE
fix(mcp): prevent CPU busy-wait spin on stderr EOF in STDIO client

### DIFF
--- a/tauri-app/src-tauri/src/mcp_client.rs
+++ b/tauri-app/src-tauri/src/mcp_client.rs
@@ -1432,6 +1432,8 @@ impl McpSession {
             let mut reader = BufReader::new(stdout).lines();
             let mut stderr_reader = BufReader::new(stderr).lines();
 
+            let mut stderr_ended = false;
+
             loop {
                 tokio::select! {
                       line_res = reader.next_line() => {
@@ -1471,7 +1473,7 @@ impl McpSession {
                              }
                          }
                       }
-                     stderr_res = stderr_reader.next_line() => {
+                     stderr_res = stderr_reader.next_line(), if !stderr_ended => {
                          // Consume stderr to prevent buffer fill
                          if let Ok(Some(line)) = stderr_res {
                              crate::app_log!("[MCP][{}][STDERR] {}", server_id_for_logs, line);
@@ -1584,7 +1586,8 @@ impl McpSession {
                              }
                              logs.push_back(line);
                          } else {
-                             // EOF on stderr
+                            // EOF or error on stderr — disable polling stderr to prevent CPU busy-wait spin
+                            stderr_ended = true;
                          }
                      }
                 }


### PR DESCRIPTION
### Описание

Исправлена проблема со 100% загрузкой одного ядра CPU (~10% общей загрузки системы), возникавшая при фоновом чтении stderr дочернего процесса STDIO MCP-сервера после достижения EOF.

### Причина проблемы

При ленивой инициализации STDIO MCP-сервера (например, при первом открытии списка инструментов MCP или выборе Конфигуратора) спавнится фоновая задача Tokio для чтения stdout и stderr процесса через tokio::select!.

```rust
// Было
loop {
    tokio::select! {
        line_res = reader.next_line() => { ... }
        stderr_res = stderr_reader.next_line() => {
            if let Ok(Some(line)) = stderr_res {
                ...
            } else {
                // EOF на stderr
            }
        }
    }
}

```

### В чём заключался баг

Когда процесс закрывает поток stderr (или завершает вывод при старте), stderr_reader.next_line().await возвращает Ok(None) (EOF).

В ветке else обработка завершалась, но опрос stderr_reader не прекращался, а цикл продолжал работу.

На всех последующих итерациях вызов .next_line() на потоке в состоянии EOF мгновенно возвращает Poll::Ready(Ok(None)) без ожидания/уступки кванта времени (yield).

tokio::select! постоянно выбирал готовую ветку stderr_res, что приводило к бесконечному плотному циклу (busy-wait spin), полностью утилизирующему один поток Tokio worker (~10% CPU).

### Решение

В src/mcp_client.rs добавлен флаг-гарда stderr_ended для ветки tokio::select!:

```rust
// Стало
let mut stderr_ended = false;
loop {
    tokio::select! {
        line_res = reader.next_line() => {
            ...
        }
        stderr_res = stderr_reader.next_line(), if !stderr_ended => {
            if let Ok(Some(line)) = stderr_res {
                ...
            } else {
                // EOF или ошибка на stderr — отключаем опрос stderr, чтобы избежать busy-wait
                stderr_ended = true;
            }
        }
    }
}

```
При наступлении EOF или ошибки на stderr флаг stderr_ended выставляется в true. Условие if !stderr_ended отключает ветку stderr_reader из выборки tokio::select!, позволяя таске корректно и без аномальной загрузки CPU ожидать данных из stdout.

### Результат

Исключена утечка ресурсов CPU после завершения вывода в stderr MCP-сервером.

Фоновый ридер теперь корректно переходит в режим ожидания (await) событий из stdout.