### PR TITLE
feat(mcp): возможность включения/отключения отдельных MCP-инструментов

### DIFF
--- a/tauri-app/src-tauri/src/ai/tools.rs
+++ b/tauri-app/src-tauri/src/ai/tools.rs
@@ -57,6 +57,7 @@ pub async fn get_available_tools() -> Vec<ToolInfo> {
     let mut futures = Vec::new();
 
     for config in enabled_configs {
+        let disabled_tools = config.disabled_tools.clone().unwrap_or_default();
         futures.push(async move {
             let server_name = config.name.clone();
             let server_id = config.id.clone();
@@ -81,7 +82,7 @@ pub async fn get_available_tools() -> Vec<ToolInfo> {
                         tools.len(),
                         duration
                     );
-                    Ok((server_id, tools))
+                    Ok((server_id, disabled_tools, tools))
                 }
                 Ok(Err(e)) => {
                     crate::app_log!(
@@ -106,8 +107,17 @@ pub async fn get_available_tools() -> Vec<ToolInfo> {
     let results = futures::future::join_all(futures).await;
 
     for res in results {
-        if let Ok((server_id, tools)) = res {
+        if let Ok((server_id, disabled_tools, tools)) = res {
             for tool in tools {
+                if disabled_tools.contains(&tool.name) {
+                    crate::app_log!(
+                        "[MCP][TOOLS] Skipping disabled tool '{}' for server '{}'",
+                        tool.name,
+                        server_id
+                    );
+                    continue;
+                }
+
                 // 1. Sanitize Name (only alphanumeric, underscore, hyphen)
                 let name = tool
                     .name

--- a/tauri-app/src-tauri/src/commands/mcp.rs
+++ b/tauri-app/src-tauri/src/commands/mcp.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 /// Struct returned to frontend with aggregated tool metadata
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct McpToolInfo {
+    pub server_id: String,
     pub server_name: String,
     pub tool_name: String,
     pub description: Option<String>,
@@ -29,6 +30,12 @@ lazy_static! {
 const MCP_TOOLS_CACHE_TTL_SECS: u64 = 300;
 const MCP_TOOLS_REQUEST_TIMEOUT_SECS: u64 = 8;
 const INTERNAL_BSL_SERVER_ID: &str = "bsl-ls";
+
+pub fn clear_mcp_tools_cache() {
+    if let Ok(mut cache_lock) = MCP_TOOLS_CACHE.lock() {
+        *cache_lock = None;
+    }
+}
 
 fn estimate_text_tokens(text: &str) -> u32 {
     if text.is_empty() {
@@ -85,8 +92,9 @@ fn estimate_mcp_tool_tokens(tool: &McpTool) -> u32 {
         .unwrap_or(0)
 }
 
-fn unavailable_tool(server_name: String, message: String) -> Vec<McpToolInfo> {
+fn unavailable_tool(server_id: String, server_name: String, message: String) -> Vec<McpToolInfo> {
     vec![McpToolInfo {
+        server_id,
         server_name,
         tool_name: "__server_unavailable__".to_string(),
         description: Some(message),
@@ -99,16 +107,20 @@ fn unavailable_tool(server_name: String, message: String) -> Vec<McpToolInfo> {
 async fn collect_server_tools(config: McpServerConfig) -> Vec<McpToolInfo> {
     let server_name = config.name.clone();
     let server_id = config.id.clone();
+    let disabled_tools = config.disabled_tools.clone().unwrap_or_default();
     let timeout = Duration::from_secs(MCP_TOOLS_REQUEST_TIMEOUT_SECS);
 
     if let Some(message) = builtin_search_unavailable_reason(&config) {
-        return unavailable_tool(server_name, message);
+        return unavailable_tool(server_id, server_name, message);
     }
 
+    let req_server_id = server_id.clone();
+    let req_config = config.clone();
+
     match tokio::time::timeout(timeout, async move {
-        let client = McpClient::new(config.clone()).await?;
+        let client = McpClient::new(req_config).await?;
         let tools = client.list_tools().await?;
-        if server_id == BUILTIN_1C_SEARCH_SERVER_ID {
+        if req_server_id == BUILTIN_1C_SEARCH_SERVER_ID {
             let (help_status, help_message) = client.get_help_state().await;
             if help_status == "unavailable" {
                 return Err(if help_message.is_empty() {
@@ -125,16 +137,18 @@ async fn collect_server_tools(config: McpServerConfig) -> Vec<McpToolInfo> {
         Ok(Ok(tools)) => tools
             .into_iter()
             .map(|tool| McpToolInfo {
+                server_id: server_id.clone(),
                 server_name: server_name.clone(),
                 estimated_tokens: estimate_mcp_tool_tokens(&tool),
+                is_enabled: !disabled_tools.contains(&tool.name),
                 tool_name: tool.name,
                 description: Some(tool.description),
                 input_schema: Some(tool.input_schema),
-                is_enabled: true,
             })
             .collect(),
-        Ok(Err(error)) => unavailable_tool(server_name, format!("Failed to list tools: {}", error)),
+        Ok(Err(error)) => unavailable_tool(server_id.clone(), server_name, format!("Failed to list tools: {}", error)),
         Err(_) => unavailable_tool(
+            server_id.clone(),
             server_name,
             format!(
                 "Timed out while loading tools after {}s",
@@ -294,6 +308,51 @@ pub async fn save_debug_logs(app_handle: tauri::AppHandle) -> Result<(), String>
     Ok(())
 }
 
+/// Toggle an MCP tool on or off for a specific server
+#[tauri::command]
+pub async fn toggle_mcp_tool(
+    server_id: String,
+    tool_name: String,
+    enabled: bool,
+) -> Result<(), String> {
+    let mut settings = load_settings();
+    let server = match settings.mcp_servers.iter_mut().find(|s| s.id == server_id) {
+        Some(s) => s,
+        None => {
+            if server_id == INTERNAL_BSL_SERVER_ID {
+                settings.mcp_servers.push(crate::settings::McpServerConfig {
+                    id: INTERNAL_BSL_SERVER_ID.to_string(),
+                    name: "BSL Language Server".to_string(),
+                    enabled: settings.bsl_server.enabled,
+                    transport: crate::settings::McpTransport::Internal,
+                    ..Default::default()
+                });
+                settings.mcp_servers.last_mut().unwrap()
+            } else {
+                return Err(format!("MCP server with ID '{}' not found", server_id));
+            }
+        }
+    };
+
+    let disabled_list = server.disabled_tools.get_or_insert_with(Vec::new);
+
+    if enabled {
+        disabled_list.retain(|name| name != &tool_name);
+    } else {
+        if !disabled_list.contains(&tool_name) {
+            disabled_list.push(tool_name.clone());
+        }
+    }
+
+    crate::settings::save_settings(&settings)
+        .map_err(|e| format!("Failed to save settings: {}", e))?;
+
+    clear_mcp_tools_cache();
+    crate::ai::tools::clear_mcp_cache();
+
+    Ok(())
+}
+
 /// Call an MCP tool on a specific server
 #[tauri::command]
 pub async fn call_mcp_tool(
@@ -321,6 +380,12 @@ pub async fn call_mcp_tool(
             }
         })
         .ok_or_else(|| format!("MCP server with ID '{}' not found", server_id))?;
+
+    if let Some(disabled) = &config.disabled_tools {
+        if disabled.contains(&name) {
+            return Err(format!("Инструмент '{}' отключен для сервера '{}'", name, server_id));
+        }
+    }
 
     let client = McpClient::new(config).await?;
     client.call_tool(&name, arguments).await
@@ -484,5 +549,40 @@ mod tests {
             .expect("custom search-index directory should resolve");
 
         assert_eq!(dir, std::path::PathBuf::from(r"D:\cfg\erp\search-index"));
+    }
+
+    #[test]
+    fn disabled_tools_deserialization_and_toggle() {
+        let json_str = r#"{
+            "id": "srv1",
+            "name": "Test Server",
+            "enabled": true,
+            "transport": "http",
+            "disabled_tools": ["tool_a", "tool_b"]
+        }"#;
+        let mut config: McpServerConfig = serde_json::from_str(json_str).unwrap();
+        assert_eq!(
+            config.disabled_tools,
+            Some(vec!["tool_a".to_string(), "tool_b".to_string()])
+        );
+
+        {
+            let disabled = config.disabled_tools.get_or_insert_with(Vec::new);
+            // Enable tool_a -> remove from list
+            disabled.retain(|n| n != "tool_a");
+        }
+        assert_eq!(config.disabled_tools, Some(vec!["tool_b".to_string()]));
+
+        {
+            let disabled = config.disabled_tools.get_or_insert_with(Vec::new);
+            // Disable tool_c -> add to list
+            if !disabled.contains(&"tool_c".to_string()) {
+                disabled.push("tool_c".to_string());
+            }
+        }
+        assert_eq!(
+            config.disabled_tools,
+            Some(vec!["tool_b".to_string(), "tool_c".to_string()])
+        );
     }
 }

--- a/tauri-app/src-tauri/src/commands/settings.rs
+++ b/tauri-app/src-tauri/src/commands/settings.rs
@@ -535,6 +535,7 @@ mod tests {
                 command: None,
                 args: None,
                 env: Some(HashMap::from([("TOKEN".to_string(), "secret".to_string())])),
+                disabled_tools: None,
             }],
             proxy: ProxySettings {
                 mode: ProxyMode::Custom,
@@ -687,6 +688,7 @@ mod tests {
                 "TOKEN".to_string(),
                 "current-secret".to_string(),
             )])),
+            disabled_tools: None,
         }];
         current.llm.providers.insert(
             "openai".to_string(),

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -105,6 +105,7 @@ pub fn run() {
             // MCP
             get_mcp_tools,
             list_mcp_tools,
+            toggle_mcp_tool,
             call_mcp_tool,
             test_mcp_connection,
             get_mcp_server_statuses,

--- a/tauri-app/src-tauri/src/settings.rs
+++ b/tauri-app/src-tauri/src/settings.rs
@@ -383,6 +383,8 @@ pub struct McpServerConfig {
     pub command: Option<String>,
     pub args: Option<Vec<String>>,
     pub env: Option<std::collections::HashMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled_tools: Option<Vec<String>>,
 }
 
 impl Default for McpServerConfig {
@@ -399,6 +401,7 @@ impl Default for McpServerConfig {
             command: None,
             args: None,
             env: None,
+            disabled_tools: None,
         }
     }
 }
@@ -1065,6 +1068,7 @@ mod tests {
                     "src/mcp-servers/1c-naparnik.ts".to_string(),
                 ]),
                 env: None,
+                disabled_tools: None,
             }],
             ..AppSettings::default()
         };

--- a/tauri-app/src/components/CodeSidePanel/McpToolsView.tsx
+++ b/tauri-app/src/components/CodeSidePanel/McpToolsView.tsx
@@ -9,6 +9,8 @@ interface McpToolsViewProps {
     serverName?: string | null;
     mcpServersOverride?: McpServerConfig[];
     bslEnabledOverride?: boolean;
+    allowToggle?: boolean;
+    onToggleTool?: (serverId: string, toolName: string, enabled: boolean) => void;
 }
 
 function getToolIdentity(tool: McpToolInfo) {
@@ -19,11 +21,14 @@ export function McpToolsView({
     serverName,
     mcpServersOverride,
     bslEnabledOverride,
+    allowToggle = false,
+    onToggleTool,
 }: McpToolsViewProps) {
     const [tools, setTools] = useState<McpToolInfo[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
     const [expandedTool, setExpandedTool] = useState<string | null>(null);
+    const [togglingTool, setTogglingTool] = useState<string | null>(null);
 
     const fetchTools = async (force = false) => {
         setLoading(true);
@@ -51,6 +56,27 @@ export function McpToolsView({
             setError(e?.toString() || 'Failed to fetch tools');
         } finally {
             setLoading(false);
+        }
+    };
+
+    const handleToggleTool = async (tool: McpToolInfo, e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (!allowToggle || !tool.server_id) return;
+
+        const toolId = getToolIdentity(tool);
+        setTogglingTool(toolId);
+        try {
+            await invoke('toggle_mcp_tool', {
+                serverId: tool.server_id,
+                toolName: tool.tool_name,
+                enabled: !tool.is_enabled,
+            });
+            onToggleTool?.(tool.server_id, tool.tool_name, !tool.is_enabled);
+            await fetchTools(true);
+        } catch (err: any) {
+            console.error('Failed to toggle MCP tool:', err);
+        } finally {
+            setTogglingTool(null);
         }
     };
 
@@ -171,7 +197,22 @@ export function McpToolsView({
                                                         ≈{formatMcpTokenCount(tool.estimated_tokens)}
                                                     </span>
                                                 )}
-                                                <div className={`w-2.5 h-2.5 rounded-full ${tool.is_enabled ? 'bg-emerald-400' : 'bg-zinc-600'}`} />
+                                                {allowToggle ? (
+                                                    <button
+                                                        type="button"
+                                                        disabled={togglingTool === toolId}
+                                                        onClick={(e) => handleToggleTool(tool, e)}
+                                                        className={`relative inline-flex h-4 w-8 items-center rounded-full transition-colors focus:outline-none ${tool.is_enabled ? 'bg-emerald-500' : 'bg-zinc-600'} ${togglingTool === toolId ? 'opacity-50 cursor-wait' : 'cursor-pointer'}`}
+                                                        title={tool.is_enabled ? "Отключить инструмент" : "Включить инструмент"}
+                                                    >
+                                                        <span className={`inline-block h-2.5 w-2.5 transform rounded-full bg-white transition-transform ${tool.is_enabled ? 'translate-x-4.5' : 'translate-x-1'}`} />
+                                                    </button>
+                                                ) : (
+                                                    <div
+                                                        className={`w-2.5 h-2.5 rounded-full ${tool.is_enabled ? 'bg-emerald-400' : 'bg-zinc-600'}`}
+                                                        title={tool.is_enabled ? "Включен" : "Отключен"}
+                                                    />
+                                                )}
                                                 <button
                                                     className="text-zinc-400 hover:text-zinc-200 p-1"
                                                     title="Info"

--- a/tauri-app/src/components/chat/McpToolsPopover.tsx
+++ b/tauri-app/src/components/chat/McpToolsPopover.tsx
@@ -21,7 +21,7 @@ function sanitizeTools(tools: McpToolInfo[]) {
     const deduped: McpToolInfo[] = [];
 
     for (const tool of tools) {
-        if (!tool.is_enabled || tool.tool_name === '__server_unavailable__') {
+        if (tool.tool_name === '__server_unavailable__') {
             continue;
         }
 
@@ -139,7 +139,7 @@ export default function McpToolsPopover({
                                     className="flex items-center justify-between px-3 py-2 hover:bg-zinc-800/50 text-left transition-colors"
                                 >
                                     <div className="min-w-0 flex-1">
-                                        <div className="text-[12px] font-medium text-zinc-200">{t.tool_name}</div>
+                                        <div className={`text-[12px] font-medium ${t.is_enabled ? 'text-zinc-200' : 'text-zinc-400'}`}>{t.tool_name}</div>
                                         {t.description && (
                                             <div className="text-[10px] text-zinc-500 line-clamp-2">{t.description}</div>
                                         )}

--- a/tauri-app/src/components/settings/MCPSettings.tsx
+++ b/tauri-app/src/components/settings/MCPSettings.tsx
@@ -155,6 +155,7 @@ export interface McpServerConfig {
     args?: string[] | null;
     env?: Record<string, string> | null;
     headers?: Record<string, string> | null;
+    disabled_tools?: string[] | null;
 }
 
 export interface McpServerStatus {
@@ -504,6 +505,39 @@ export function MCPSettings({
 
     const handleUpdateServer = (id: string, updates: Partial<McpServerConfig>) => {
         onUpdate(servers.map(s => s.id === id ? { ...s, ...updates } : s));
+    };
+
+    const handleToggleToolInSettings = (serverId: string, toolName: string, enabled: boolean) => {
+        let found = false;
+        const updatedServers = servers.map(server => {
+            if (server.id !== serverId) return server;
+            found = true;
+            const currentDisabled = server.disabled_tools ?? [];
+            let newDisabled: string[];
+            if (enabled) {
+                newDisabled = currentDisabled.filter(t => t !== toolName);
+            } else {
+                newDisabled = currentDisabled.includes(toolName)
+                    ? currentDisabled
+                    : [...currentDisabled, toolName];
+            }
+            return {
+                ...server,
+                disabled_tools: newDisabled,
+            };
+        });
+
+        if (!found) {
+            updatedServers.push({
+                id: serverId,
+                name: serverId,
+                enabled: true,
+                transport: 'internal',
+                disabled_tools: enabled ? [] : [toolName],
+            });
+        }
+
+        onUpdate(updatedServers);
     };
 
     const handleTestConnection = async (config: McpServerConfig) => {
@@ -1718,6 +1752,8 @@ export function MCPSettings({
                                 serverName={servers.find(s => s.id === viewingToolsId)?.name ?? null}
                                 mcpServersOverride={servers}
                                 bslEnabledOverride={bslEnabled}
+                                allowToggle={true}
+                                onToggleTool={handleToggleToolInSettings}
                             />
                         </div>
                     </div>

--- a/tauri-app/src/types/mcp.ts
+++ b/tauri-app/src/types/mcp.ts
@@ -1,4 +1,5 @@
 export interface McpToolInfo {
+  server_id?: string;
   server_name: string;
   tool_name: string;
   description: string | null;

--- a/tauri-app/src/types/settings.ts
+++ b/tauri-app/src/types/settings.ts
@@ -119,6 +119,7 @@ export interface McpServerConfig {
     command?: string | null;
     args?: string[] | null;
     env?: Record<string, string> | null;
+    disabled_tools?: string[] | null;
 }
 
 export type ProxyMode = 'system' | 'disabled' | 'custom';

--- a/tauri-app/src/utils/__tests__/mcpTokenUsage.test.ts
+++ b/tauri-app/src/utils/__tests__/mcpTokenUsage.test.ts
@@ -6,6 +6,7 @@ import { summarizeMcpTokenUsage } from '../mcpTokenUsage';
 test('summarizeMcpTokenUsage groups enabled tools by server and totals token estimates', () => {
     const summary = summarizeMcpTokenUsage([
         {
+            server_id: 'builtin-1c-search',
             server_name: '1С:Поиск',
             tool_name: 'find_symbol',
             description: 'Найти символ',
@@ -14,6 +15,7 @@ test('summarizeMcpTokenUsage groups enabled tools by server and totals token est
             estimated_tokens: 120,
         },
         {
+            server_id: 'builtin-1c-search',
             server_name: '1С:Поиск',
             tool_name: 'search_code',
             description: 'Поиск кода',
@@ -22,6 +24,7 @@ test('summarizeMcpTokenUsage groups enabled tools by server and totals token est
             estimated_tokens: 80,
         },
         {
+            server_id: 'builtin-1c-naparnik',
             server_name: '1С:Напарник',
             tool_name: 'ask_1c_ai',
             description: 'Вопрос ИТС',
@@ -30,6 +33,7 @@ test('summarizeMcpTokenUsage groups enabled tools by server and totals token est
             estimated_tokens: 40,
         },
         {
+            server_id: 'disabled-server',
             server_name: 'Отключен',
             tool_name: 'disabled_tool',
             description: null,
@@ -38,6 +42,7 @@ test('summarizeMcpTokenUsage groups enabled tools by server and totals token est
             estimated_tokens: 900,
         },
         {
+            server_id: 'unavail-server',
             server_name: 'Недоступен',
             tool_name: '__server_unavailable__',
             description: null,


### PR DESCRIPTION
## Краткий обзор (Summary)

Данный Pull Request добавляет возможность гранулярного управления MCP-инструментами. Теперь пользователи могут отключать или включать конкретные инструменты (tools) внутри каждого MCP-сервера отдельно, не отключая сам сервер целиком. 

Это позволяет гибко настраивать контекст для ИИ-ассистента, экономить токены и защищать систему от вызова ненужных или тяжелых инструментов.

---

## Ключевые изменения

1. **Гранулярный тумблер (Toggle) для каждого инструмента**:
   - В окне настроек MCP (`MCPSettings`) для каждого инструмента добавлен интерактивный переключатель (Toggle).
   - Изменения состояния инструмента мгновенно сохраняются в конфиг и сбрасывают кэш инструментов.
2. **Исключение отключенных инструментов из контекста LLM**:
   - Отключенные инструменты не передаются ИИ-модели при формировании запроса, благодаря чему модель о них не знает и не тратит на них системный контекст.
3. **Защита на уровне бэкенда**:
   - В команду `call_mcp_tool` добавлена валидация: при попытке вызвать отключенный инструмент команда возвращает явную ошибку.
4. **Визуальная индикация в интерфейсе**:
   - В UI списка инструментов (`McpToolsView` и `McpToolsPopover`) отключенные инструменты наглядно подсвечиваются серым цветом.

---

## Детали реализации

### Backend (Rust / Tauri)

- [`settings.rs`](/tauri-app/src-tauri/src/settings.rs):
  - В структуру `McpServerConfig` добавлено опциональное поле `disabled_tools: Option<Vec<String>>` (массив наименований отключенных инструментов) с поддержкой обратной совместимости при сериализации/десериализации JSON.
- [`commands/mcp.rs`](/tauri-app/src-tauri/src/commands/mcp.rs):
  - **`McpToolInfo`**: добавлено поле `server_id: String` для однозначной привязки инструмента к соответствующему MCP-серверу.
  - **`collect_server_tools`**: флаг `is_enabled` теперь динамически вычисляется на основе наличия названия инструмента в `disabled_tools`.
  - **`toggle_mcp_tool`**: добавлена новая Tauri-команда для включения/отключения инструмента по `server_id` и `tool_name`. Автоматически сбрасывает кэш MCP-инструментов и обновляет конфигурацию.
  - **`call_mcp_tool`**: добавлена проверка наличия инструмента в `disabled_tools` перед вызовом.
  - **Тесты**: добавлен модульный тест `disabled_tools_deserialization_and_toggle` для проверки сериализации и работы логики переключения.
- [`ai/tools.rs`](/tauri-app/src-tauri/src/ai/tools.rs):
  - Функция `get_available_tools` фильтрует отключенные инструменты при сборке доступных системных промптов/инструментов для ИИ-модели.
- [`lib.rs`](/tauri-app/src-tauri/src/lib.rs):
  - Зарегистрирована новая Tauri-команда `toggle_mcp_tool`.

### Frontend (React / TypeScript)

- [`types/settings.ts`](/tauri-app/src/types/settings.ts) & [`types/mcp.ts`](/tauri-app/src/types/mcp.ts):
  - Обновлены TypeScript-интерфейсы `McpServerConfig` (поле `disabled_tools`) и `McpToolInfo` (поле `server_id`).
- [`McpToolsView.tsx`](/tauri-app/src/components/CodeSidePanel/McpToolsView.tsx):
  - Добавлены пропсы `allowToggle` и `onToggleTool`.
  - Реализован компонент переключателя с анимацией переключения и состояния загрузки (disabled/wait cursor во время сохранения).
- [`MCPSettings.tsx`](/tauri-app/src/components/settings/MCPSettings.tsx):
  - Внедрен обработчик `handleToggleToolInSettings`, передающий `allowToggle={true}` в просмотрщик инструментов.
- [`McpToolsPopover.tsx`](/tauri-app/src/components/chat/McpToolsPopover.tsx):
  - Настроено отображение статуса отключенных инструментов (тусклый цвет текста `text-zinc-400`).
- [`mcpTokenUsage.test.ts`](/tauri-app/src/utils/__tests__/mcpTokenUsage.test.ts):
  - Обновлены тесты расчета расхода токенов с учетом добавления `server_id`.

---

## Проверка и тестирование

- [x] **Юнит-тесты на Rust**: пройден тест `disabled_tools_deserialization_and_toggle`.
- [x] **Юнит-тесты на TS/Jest**: обновлены и пройдены тесты для `mcpTokenUsage`.
- [x] **Ручное тестирование UI**:
  - Переключатель в настройках корректно отключает инструмент.
  - При повторном запросе ИИ отключенный инструмент не попадает в список доступных функций (Tool schema).
  - При включении инструмент моментально становится доступен снова.
  
##  Связанные задачи
Resolves #175
