### PR TITLE
fix(ai): исправление ошибки 400 Bad Request при вызове инструментов в Google Gemini API

### DIFF
--- a/tauri-app/src-tauri/src/ai/client.rs
+++ b/tauri-app/src-tauri/src/ai/client.rs
@@ -880,6 +880,7 @@ pub async fn stream_chat_completion(
                         .filter(|s| !s.is_empty())
                         .unwrap_or_else(|| "{}".to_string()),
                 },
+                extra_content: tc.extra_content,
             })
             .collect();
         if !content.is_empty() {
@@ -893,6 +894,24 @@ pub async fn stream_chat_completion(
                     "index": idx, "id": tc.id, "name": tc.function.name
                 }),
             );
+            let _ = app_handle.emit(
+                "tool-call-progress",
+                serde_json::json!({
+                    "index": idx, "arguments": tc.function.arguments
+                }),
+            );
+            if let Some(ts) = tc.extra_content
+                .as_ref()
+                .and_then(|ec| ec.google.as_ref())
+                .and_then(|g| g.thought_signature.as_ref())
+            {
+                let _ = app_handle.emit(
+                    "tool-call-signature",
+                    serde_json::json!({
+                        "index": idx, "signature": ts
+                    }),
+                );
+            }
         }
         crate::app_log!(
             "[AI][RESP] non-stream content_chars={} tool_calls={}",
@@ -1315,6 +1334,7 @@ pub async fn stream_chat_completion(
                                                         name: fn_name.clone(),
                                                         arguments: args,
                                                     },
+                                                    extra_content: None,
                                                 };
                                                 let _ = app_handle.emit("tool-call-started", serde_json::json!({
                                                     "index": tc_idx, "id": tc.id, "name": fn_name
@@ -1371,6 +1391,7 @@ pub async fn stream_chat_completion(
                                                 name: fn_name.clone(),
                                                 arguments: args_json,
                                             },
+                                            extra_content: None,
                                         };
                                         let _ = app_handle.emit(
                                             "tool-call-started",
@@ -1396,6 +1417,7 @@ pub async fn stream_chat_completion(
                                                 name: String::new(),
                                                 arguments: String::new(),
                                             },
+                                            extra_content: None,
                                         });
                                     }
 
@@ -1420,6 +1442,27 @@ pub async fn stream_chat_completion(
                                                 }),
                                             );
                                         }
+                                    }
+                                    // Accumulate extra_content.google.thought_signature from delta
+                                    if let Some(ts) = tc_delta.extra_content
+                                        .as_ref()
+                                        .and_then(|ec| ec.google.as_ref())
+                                        .and_then(|g| g.thought_signature.as_ref())
+                                    {
+                                        let existing_sig = tc.extra_content
+                                            .get_or_insert_with(|| ExtraContent { google: None })
+                                            .google
+                                            .get_or_insert_with(|| GoogleExtraContent { thought_signature: None })
+                                            .thought_signature
+                                            .get_or_insert_with(String::new);
+                                        existing_sig.push_str(ts);
+                                        let _ = app_handle.emit(
+                                            "tool-call-signature",
+                                            serde_json::json!({
+                                                "index": idx,
+                                                "signature": ts
+                                            }),
+                                        );
                                     }
 
                                     if !announced_tool_calls.contains(&idx)
@@ -1673,6 +1716,7 @@ mod tests {
                         name: "search_code".to_string(),
                         arguments: "{}".to_string(),
                     },
+                    extra_content: None,
                 }]),
                 tool_call_id: None,
                 name: None,

--- a/tauri-app/src-tauri/src/ai/codex_client.rs
+++ b/tauri-app/src-tauri/src/ai/codex_client.rs
@@ -868,6 +868,7 @@ pub async fn stream_codex_completion(
                                         name: name.clone(),
                                         arguments: arguments.clone(),
                                     },
+                                    extra_content: None,
                                 });
                                 pending_calls.remove(&call_id);
                                 crate::app_log!(
@@ -893,6 +894,7 @@ pub async fn stream_codex_completion(
                                         name: name.clone(),
                                         arguments: arguments.clone(),
                                     },
+                                    extra_content: None,
                                 });
                                 crate::app_log!(
                                     "[Codex] Function call completed (args.done): {} args_len={}",
@@ -921,7 +923,11 @@ pub async fn stream_codex_completion(
                         accumulated_tool_calls.push(ToolCall {
                             id: call_id,
                             r#type: "function".to_string(),
-                            function: ToolCallFunction { name, arguments },
+                            function: ToolCallFunction {
+                                name,
+                                arguments,
+                            },
+                            extra_content: None,
                         });
                     }
 
@@ -1067,6 +1073,7 @@ mod tests {
                         name: "check_bsl_syntax".to_string(),
                         arguments: "{}".to_string(),
                     },
+                    extra_content: None,
                 }]),
                 tool_call_id: None,
                 name: None,
@@ -1092,6 +1099,7 @@ mod tests {
                         name: "check_bsl_syntax".to_string(),
                         arguments: "{\"code\":\"Сообщить(\\\"ok\\\");\"}".to_string(),
                     },
+                    extra_content: None,
                 }]),
                 tool_call_id: None,
                 name: None,

--- a/tauri-app/src-tauri/src/ai/models.rs
+++ b/tauri-app/src-tauri/src/ai/models.rs
@@ -30,10 +30,22 @@ pub struct ApiMessage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoogleExtraContent {
+    pub thought_signature: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtraContent {
+    pub google: Option<GoogleExtraContent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCall {
     pub id: String,
     pub r#type: String,
     pub function: ToolCallFunction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_content: Option<ExtraContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -103,6 +115,7 @@ pub struct ToolCallDelta {
     #[allow(dead_code)]
     pub r#type: Option<String>, // Renamed from _type for consistency and to avoid prefix
     pub function: Option<ToolCallFunctionDelta>,
+    pub extra_content: Option<ExtraContent>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -135,6 +148,7 @@ pub struct NonStreamToolCall {
     pub id: String,
     pub r#type: String,
     pub function: NonStreamToolCallFunction,
+    pub extra_content: Option<ExtraContent>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/tauri-app/src-tauri/src/commands/ai.rs
+++ b/tauri-app/src-tauri/src/commands/ai.rs
@@ -9,6 +9,8 @@ pub struct FrontendToolCall {
     pub id: String,
     pub r#type: String,
     pub function: FrontendToolCallFunction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_content: Option<crate::ai::models::ExtraContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -329,6 +331,7 @@ fn build_forced_bsl_syntax_tool_call(
             name: "check_bsl_syntax".to_string(),
             arguments: arguments.clone(),
         },
+        extra_content: None,
     };
 
     (tool_call_id, arguments_value, arguments, tool_call)
@@ -460,6 +463,7 @@ pub async fn stream_chat(
                             name: tc.function.name,
                             arguments: tc.function.arguments,
                         },
+                        extra_content: tc.extra_content,
                     })
                     .collect::<Vec<_>>()
             });
@@ -1318,6 +1322,7 @@ mod tests {
                     name: "search_code".to_string(),
                     arguments: "{}".to_string(),
                 },
+                extra_content: None,
             }]),
             tool_call_id: None,
             name: None,

--- a/tauri-app/src/api/chat.ts
+++ b/tauri-app/src/api/chat.ts
@@ -7,6 +7,11 @@ export interface ChatToolCall {
         name: string;
         arguments: string;
     };
+    extra_content?: {
+        google?: {
+            thought_signature?: string;
+        };
+    };
 }
 
 export interface ChatMessage {

--- a/tauri-app/src/contexts/ChatContext.tsx
+++ b/tauri-app/src/contexts/ChatContext.tsx
@@ -19,6 +19,7 @@ export interface ToolCall {
     result?: string;
     startedAt?: number;
     duration?: number;
+    thought_signature?: string;
 }
 
 export interface BSLDiagnostic {
@@ -186,8 +187,15 @@ function buildPayloadMessages(
                         type: 'function',
                         function: {
                             name: tc.name,
-                            arguments: tc.arguments || '{}'
-                        }
+                            arguments: tc.arguments || '{}',
+                        },
+                        ...(tc.thought_signature ? {
+                            extra_content: {
+                                google: {
+                                    thought_signature: tc.thought_signature,
+                                }
+                            }
+                        } : undefined),
                     }))
                 };
                 const toolResults: api.ChatMessage[] = completedToolCalls
@@ -480,6 +488,33 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
                                 toolCalls[tcIdx] = {
                                     ...toolCalls[tcIdx],
                                     arguments: toolCalls[tcIdx].arguments + event.payload.arguments
+                                };
+                            }
+
+                            return [
+                                ...prev.slice(0, lastAssistantIdx),
+                                { ...last, toolCalls },
+                                ...prev.slice(lastAssistantIdx + 1)
+                            ];
+                        });
+                    }),
+                    listen<{ index: number, signature: string }>('tool-call-signature', (event) => {
+                        setMessages(prev => {
+                            let lastAssistantIdx = -1;
+                            for (let i = prev.length - 1; i >= 0; i--) {
+                                if (prev[i].role === 'user') break;
+                                if (prev[i].role === 'assistant' && prev[i].toolCalls) { lastAssistantIdx = i; break; }
+                            }
+                            if (lastAssistantIdx === -1) return prev;
+
+                            const last = prev[lastAssistantIdx];
+                            const toolCalls = [...last.toolCalls!];
+                            const toolId = currentBatchToolIds.current[event.payload.index];
+                            const tcIdx = toolId ? toolCalls.findIndex(tc => tc.id === toolId) : -1;
+                            if (tcIdx !== -1) {
+                                toolCalls[tcIdx] = {
+                                    ...toolCalls[tcIdx],
+                                    thought_signature: (toolCalls[tcIdx].thought_signature || '') + event.payload.signature
                                 };
                             }
 


### PR DESCRIPTION
## Описание проблемы

При работе с новыми моделями Gemini 3.x в режиме рассуждений (thinking) через OpenAI-совместимый эндпоинт Google (`generativelanguage.googleapis.com/v1beta/openai`), отправка истории вызова функций (tool calls) приводила к ошибке `400 Bad Request` / `400 Invalid Argument` на последующих шагах диалога.

### Причина:
Модели Gemini с поддержкой thinking генерируют зашифрованную непрозрачную строку — `thought_signature`. Она служит «блоком памяти», сохраняющим внутреннее состояние рассуждения модели при вызове функций. Google API требует, чтобы эта сигнатура возвращалась обратно в историю сообщений в последующих запросах с результатами вызова функций.

В спецификации OpenAI-совместимого эндпоинта Google сигнатура `thought_signature` передаётся на верхнем уровне вызова инструмента (`ToolCall`) — в структуре `extra_content.google.thought_signature`. Поскольку данная сигнатура ранее не обрабатывалась, запрос отклонялся сервером Google с ошибкой `400`.

**Формат ответа и ожидания Google API:**
```json
{
  "tool_calls": [{
    "id": "call_123",
    "type": "function",
    "function": {
      "name": "check_bsl_syntax",
      "arguments": "{...}"
    },
    "extra_content": {
      "google": {
        "thought_signature": "eYJhbGciOi..."
      }
    }
  }]
}
```

---

## Решение

Реализована поддержка передачи `thought_signature` на уровне `ToolCall` в объекте `extra_content.google.thought_signature`:

1. Поддержка `extra_content` добавлена в бэкенд-модели Rust, обработчики ответов (как стриминговых, так и нестриминговых) и интерфейсы фронтенда.
2. Для сохранения полной обратной совместимости с другими LLM-провайдерами (OpenAI, Anthropic, Qwen и др.) используется макрос `#[serde(skip_serializing_if = "Option::is_none")]`. Для других провайдеров поле `extra_content` просачиваться в JSON не будет.

---

### Подробное описание изменений по файлам

#### Бэкенд (Rust / Tauri)

* **[models.rs](/tauri-app/src-tauri/src/ai/models.rs)**
  * Добавлены структуры `GoogleExtraContent` (`thought_signature: Option<String>`) и `ExtraContent` (`google: Option<GoogleExtraContent>`).
  * Поле `extra_content: Option<ExtraContent>` добавлено в структуры `ToolCall`, `ToolCallDelta` и `NonStreamToolCall`.
  * Поле `extra_content` в `ToolCall` размечено атрибутом `#[serde(skip_serializing_if = "Option::is_none")]`.

* **[client.rs](/tauri-app/src-tauri/src/ai/client.rs)**
  * **Non-stream режим:** извлечение `extra_content` из `NonStreamToolCall` и перенос в `ToolCall`. Добавлена отправка событий `tool-call-signature` и `tool-call-progress` на фронтенд при наличии сигнатуры.
  * **Stream режим:** инкрементальное накопление фрагментов `thought_signature` из `ToolCallDelta.extra_content` в `ToolCall.extra_content` во время стриминга ответа и генерация событий `tool-call-signature`.
  * Обновлены конструкторы `ToolCall` и тесты (`extra_content: None`).

* **[ai.rs](/tauri-app/src-tauri/src/commands/ai.rs)**
  * Добавлено поле `extra_content: Option<ExtraContent>` в структуру `FrontendToolCall` (с `skip_serializing_if`).
  * В `stream_chat` добавлена трансляция `extra_content` из ответа AI-клиента на фронтенд.
  * Обновлены синтетические вызовы инструментов и модульные тесты (`extra_content: None`).

* **[codex_client.rs](/tauri-app/src-tauri/src/ai/codex_client.rs)**
  * Инициализация `ToolCall` обновлена добавлением `extra_content: None`.

#### Фронтенд (TypeScript / React)

* **[chat.ts](/tauri-app/src/api/chat.ts)**
  * В интерфейс `ChatToolCall` добавлено поле `extra_content?: { google?: { thought_signature?: string } }` на уровне вызова инструмента.

* **[ChatContext.tsx](/tauri-app/src/contexts/ChatContext.tsx)**
  * В внутренний интерфейс `ToolCall` добавлено поле `thought_signature?: string`.
  * В функции `buildPayloadMessages` добавлена сборка объекта `extra_content.google.thought_signature` на уровне вызова инструмента при формировании запросов в API.
  * Добавлен подписчик на событие `tool-call-signature`, аккумулирующий фрагменты сигнатуры в активном вызове инструмента в стейте.

---

## Тестирование и проверка

### Автоматические тесты
- `cargo check` в `tauri-app/src-tauri` — успешно пройдено.
- `npx tsc --noEmit` в `tauri-app` — проверка типов TypeScript успешно пройдена.

### Ручное тестирование
- Ручное тестирование проводилось на **Google API в Google AI Studio (free tier)** на модели **Gemini 3.5 Flash Lite**.
- Проверены сценарии с последовательными вызовами функций (tool calls) и возвратом результатов выполнения на следующих шагах:
  - `thought_signature` корректно считывается при стриминге.
  - `thought_signature` корректно отправляется обратно в `extra_content.google.thought_signature`.
  - Ошибка `400 Bad Request` полностью устранена, вызовы функций и диалог функционируют штатно.